### PR TITLE
Fix spritesheet dimensions

### DIFF
--- a/GifImporter/GifImporter.cs
+++ b/GifImporter/GifImporter.cs
@@ -93,7 +93,7 @@ namespace GifImporter
                         float ratio = (float)frameWidth / frameHeight;
                         var cols = MathX.Sqrt(frameCount / ratio);
                         gifCols = MathX.RoundToInt(cols);
-                        gifRows = MathX.CeilToInt((double) frameCount / gifCols);
+                        gifRows = frameCount / gifCols + (frameCount % gifCols != 0) ? 1 : 0;
 
                         // Create a new image
                         spriteSheet = new Bitmap(frameWidth * gifCols, frameHeight * gifRows);

--- a/GifImporter/GifImporter.cs
+++ b/GifImporter/GifImporter.cs
@@ -92,8 +92,8 @@ namespace GifImporter
                         // calculate amount of cols and rows
                         float ratio = (float)frameWidth / frameHeight;
                         var cols = MathX.Sqrt(frameCount / ratio);
-                        gifRows = MathX.RoundToInt(ratio * cols);
                         gifCols = MathX.RoundToInt(cols);
+                        gifRows = MathX.CeilToInt(frameCount / gifCols);
 
                         // Create a new image
                         spriteSheet = new Bitmap(frameWidth * gifCols, frameHeight * gifRows);

--- a/GifImporter/GifImporter.cs
+++ b/GifImporter/GifImporter.cs
@@ -93,7 +93,7 @@ namespace GifImporter
                         float ratio = (float)frameWidth / frameHeight;
                         var cols = MathX.Sqrt(frameCount / ratio);
                         gifCols = MathX.RoundToInt(cols);
-                        gifRows = MathX.CeilToInt(frameCount / gifCols);
+                        gifRows = MathX.CeilToInt((double) frameCount / gifCols);
 
                         // Create a new image
                         spriteSheet = new Bitmap(frameWidth * gifCols, frameHeight * gifRows);


### PR DESCRIPTION
This guarantees that the number of cells in the sprite sheet will be greater than or equal to the number of frames in the GIF.